### PR TITLE
Add copy/paste support to the editor

### DIFF
--- a/editor/src/App.jsx
+++ b/editor/src/App.jsx
@@ -310,6 +310,44 @@ function App() {
 
     logEditor("Textarea keydown", {index, endSelection, value: e.target.value, key: e.key});
 
+    if ((e.metaKey || e.ctrlKey) && e.key === "c") {
+      e.preventDefault();
+      const selected = endSelection > index ? words.slice(index, endSelection) : words;
+      navigator.clipboard.writeText(joinWords(selected));
+      return;
+    }
+
+    if ((e.metaKey || e.ctrlKey) && e.key === "x") {
+      e.preventDefault();
+      if (endSelection > index) {
+        navigator.clipboard.writeText(joinWords(words.slice(index, endSelection)));
+        const newWords = [...words];
+        newWords.splice(index, endSelection - index);
+        setWords(newWords);
+        fire(() => {
+          textareaRef.current.focus();
+          textareaRef.current.setSelectionRange(index, index);
+        });
+      }
+      return;
+    }
+
+    if ((e.metaKey || e.ctrlKey) && e.key === "v") {
+      e.preventDefault();
+      navigator.clipboard.readText().then((text) => {
+        const pasted = splitWordsWithNewlines(text);
+        const newWords = [...words];
+        const deleteCount = endSelection > index ? endSelection - index : 0;
+        newWords.splice(index, deleteCount, ...pasted);
+        setWords(newWords);
+        fire(() => {
+          textareaRef.current.focus();
+          textareaRef.current.setSelectionRange(index + pasted.length, index + pasted.length);
+        });
+      });
+      return;
+    }
+
     // Do nothing if the user holds down the meta key.
     if (e.metaKey) return;
 


### PR DESCRIPTION
## Summary

- Intercepts `Cmd/Ctrl+C`, `Cmd/Ctrl+X`, and `Cmd/Ctrl+V` in `onTextareaKeyDown` before the existing meta-key guard
- **Copy**: serializes selected words (or all words when nothing is selected) via `joinWords()` and writes to the clipboard — the browser never sees the `中中中` placeholder content
- **Cut**: same as copy, then removes the selected words from state
- **Paste**: reads the clipboard, parses it with `splitWordsWithNewlines()`, and splices the resulting word objects in at the cursor (replacing any active selection)

All other `Cmd/Ctrl+…` shortcuts (Undo, Select All, etc.) continue to go through the browser as before.

Closes #36

## Test plan

- [x] Type a few words, select some, Cmd+C → paste into a plain text editor → real words appear (not `中中中`)
- [x] Same selection, Cmd+X → words removed from editor; clipboard contains real text
- [x] Copy text externally, Cmd+V in the editor → words are inserted at cursor
- [x] Paste with an active selection → selection is replaced by pasted text
- [x] Cmd+Z / Cmd+A still work via browser default

🤖 Generated with [Claude Code](https://claude.com/claude-code)