### PR TITLE
Add auto-wrap and editor UX fixes

### DIFF
--- a/editor/src/App.jsx
+++ b/editor/src/App.jsx
@@ -149,11 +149,16 @@ function App() {
     const containerWidth = container.clientWidth;
     const containerHeight = container.clientHeight;
 
-    if (width < containerWidth) editorRef.current.style.left = (containerWidth - width) / 2 + "px";
-    else editorRef.current.style.left = "10px";
+    const marginLeft = width < containerWidth ? (containerWidth - width) / 2 : 10;
+    const marginTop = Math.max(height < containerHeight ? (containerHeight - height) / 2 : 100, 100);
 
-    if (height < containerHeight) editorRef.current.style.top = (containerHeight - height) / 2 + "px";
-    else editorRef.current.style.top = "100px";
+    editorRef.current.style.top = "0px";
+    editorRef.current.style.left = "0px";
+    editorRef.current.style.marginLeft = marginLeft + "px";
+    editorRef.current.style.marginTop = marginTop + "px";
+    editorRef.current.style.marginBottom = "200px";
+    editorRef.current.style.width = width + "px";
+    editorRef.current.style.height = height + "px";
   };
 
   useEffect(() => {

--- a/editor/src/App.jsx
+++ b/editor/src/App.jsx
@@ -359,6 +359,10 @@ function App() {
     // Do nothing if the user holds down the meta key.
     if (e.metaKey) return;
 
+    // Ignore non-content keys (arrows, Tab, Escape, Alt/Option, Shift, F-keys, etc.)
+    // so that a selection is never accidentally wiped by a key that doesn't type anything.
+    if (!isPrintable(e.key) && e.key !== " " && e.key !== "Backspace" && e.key !== "Enter") return;
+
     const newWords = [...words];
 
     // If the user selects a part of the text, remove it.

--- a/editor/src/App.jsx
+++ b/editor/src/App.jsx
@@ -33,6 +33,8 @@ function createDefaultConfig() {
     padding: 0,
     canvas: "transparent",
     cursive: false,
+    autoWrap: true,
+    wrapWidth: 1000,
     word: {
       fill: "transparent",
       strokeWidth: 1.5,
@@ -107,11 +109,16 @@ function App() {
 
   const {width: cellWidth, height: cellHeight} = useMemo(() => measureText(ch, style), [ch, style]);
 
-  const placeholderWords = useMemo(() => positionWords(splitWordsWithNewlines(placeHolder)), [placeHolder]);
+  const cols = config.autoWrap ? Math.floor(+config.wrapWidth / cellWidth) : Infinity;
+
+  const placeholderWords = useMemo(
+    () => positionWords(splitWordsWithNewlines(placeHolder), {cols}),
+    [placeHolder, cols],
+  );
 
   const [words, setWords] = useState(splitWordsWithNewlines(text));
 
-  positionWords(words);
+  positionWords(words, {cols});
 
   const textareaValue = useMemo(() => {
     // Show \n as is. There is no need to show it as a Chinese character.
@@ -122,30 +129,30 @@ function App() {
     return cellWidth / cellHeight;
   }, [cellWidth, cellHeight]);
 
-  const computeEditorPosition = (textareaValue, style) => {
-    const placeholderText = placeHolder
-      .split(" ")
-      .map(() => ch)
-      .join("");
+  const computeEditorPosition = () => {
+    if (!textareaRef.current || !editorContainerRef.current) return;
 
-    // Center the textarea based on the size of the output,
-    // not the size of the textarea, because the textarea is not visible.
-    if (textareaRef.current && editorContainerRef.current) {
-      const {width, height: h} = measureText(textareaValue || placeholderText, style);
+    const isEmpty = words.length === 0;
+    const W = isEmpty ? placeholderWords : words;
+    if (W.length === 0) return;
 
-      // Apply the scale to the height.
-      const height = h * scale;
+    const maxX = Math.max(...W.map((d) => d.x));
+    const maxY = Math.max(...W.map((d) => d.y));
+    const lastWord = W[W.length - 1];
+    const offset = lastWord && lastWord.ch === "\n" ? 1 : 0;
 
-      const container = editorContainerRef.current;
-      const containerWidth = container.clientWidth;
-      const containerHeight = container.clientHeight;
+    const width = (maxX + 1) * cellWidth;
+    const height = (maxY + 1 + offset) * cellHeight * scale;
 
-      if (width < containerWidth) editorRef.current.style.left = (containerWidth - width) / 2 + "px";
-      else editorRef.current.style.left = "10px";
+    const container = editorContainerRef.current;
+    const containerWidth = container.clientWidth;
+    const containerHeight = container.clientHeight;
 
-      if (height < containerHeight) editorRef.current.style.top = (containerHeight - height) / 2 + "px";
-      else editorRef.current.style.top = "100px";
-    }
+    if (width < containerWidth) editorRef.current.style.left = (containerWidth - width) / 2 + "px";
+    else editorRef.current.style.left = "10px";
+
+    if (height < containerHeight) editorRef.current.style.top = (containerHeight - height) / 2 + "px";
+    else editorRef.current.style.top = "100px";
   };
 
   useEffect(() => {
@@ -173,18 +180,18 @@ function App() {
   }, []);
 
   useEffect(() => {
-    computeEditorPosition(textareaValue, style);
-  }, [textareaValue, style]);
+    computeEditorPosition();
+  }, [words, cellWidth, cellHeight, cols]);
 
   // Add resize observer for editor container
   useEffect(() => {
     if (!editorContainerRef.current) return;
     const resizeObserver = new ResizeObserver(() => {
-      computeEditorPosition(textareaValue, style);
+      computeEditorPosition();
     });
     resizeObserver.observe(editorContainerRef.current);
     return () => resizeObserver.disconnect();
-  }, [textareaValue, style]);
+  }, [words, cellWidth, cellHeight, cols]);
 
   useEffect(() => {
     if (textareaRef.current) {

--- a/editor/src/App.jsx
+++ b/editor/src/App.jsx
@@ -157,6 +157,7 @@ function App() {
     editorRef.current.style.marginLeft = marginLeft + "px";
     editorRef.current.style.marginTop = marginTop + "px";
     editorRef.current.style.marginBottom = "200px";
+    editorRef.current.style.marginRight = "200px";
     editorRef.current.style.width = width + "px";
     editorRef.current.style.height = height + "px";
   };

--- a/editor/src/App.jsx
+++ b/editor/src/App.jsx
@@ -95,6 +95,7 @@ function App() {
   const [showExample, setShowExample] = useState(false);
   const [template, setTemplate] = useState("None");
   const [config, setConfig] = useState(getConfig());
+  const [containerWidth, setContainerWidth] = useState(Infinity);
 
   const text = config.text;
 
@@ -109,7 +110,7 @@ function App() {
 
   const {width: cellWidth, height: cellHeight} = useMemo(() => measureText(ch, style), [ch, style]);
 
-  const cols = config.autoWrap ? Math.floor(+config.wrapWidth / cellWidth) : Infinity;
+  const cols = config.autoWrap ? Math.floor(Math.min(containerWidth, +config.wrapWidth) / cellWidth) : Infinity;
 
   const placeholderWords = useMemo(
     () => positionWords(splitWordsWithNewlines(placeHolder), {cols}),
@@ -168,7 +169,7 @@ function App() {
         }),
       );
     }
-  }, [words, cellWidth, config]);
+  }, [words, cellWidth, config, cols]);
 
   // When enter the page, focus on the textarea.
   useEffect(() => {
@@ -181,17 +182,17 @@ function App() {
 
   useEffect(() => {
     computeEditorPosition();
-  }, [words, cellWidth, cellHeight, cols]);
+  }, [words, cellWidth, cellHeight, cols, containerWidth]);
 
-  // Add resize observer for editor container
+  // Track container width so cols (and centering) react to window resize.
   useEffect(() => {
     if (!editorContainerRef.current) return;
-    const resizeObserver = new ResizeObserver(() => {
-      computeEditorPosition();
+    const resizeObserver = new ResizeObserver((entries) => {
+      setContainerWidth(entries[0].contentRect.width);
     });
     resizeObserver.observe(editorContainerRef.current);
     return () => resizeObserver.disconnect();
-  }, [words, cellWidth, cellHeight, cols]);
+  }, []);
 
   useEffect(() => {
     if (textareaRef.current) {
@@ -209,7 +210,7 @@ function App() {
       textareaRef.current.style.width = `${(maxX + 1) * cellWidth}px`;
       textareaRef.current.style.height = `${(maxY + 1 + offset) * cellHeight}px`;
     }
-  }, [words, cellWidth, cellHeight]);
+  }, [words, cellWidth, cellHeight, cols]);
 
   const fire = (callback) => setTimeout(callback, 10);
 

--- a/editor/src/App.jsx
+++ b/editor/src/App.jsx
@@ -562,7 +562,12 @@ function App() {
           <textarea
             className="input"
             // If the textarea is empty, adjust the position of the cursor by 10px.
-            style={{...style, transform: `scale(1, ${scale}) ${textareaValue ? "" : "translate(0, 10px)"}`}}
+            style={{
+              ...style,
+              lineHeight: `${cellHeight}px`,
+              padding: 0,
+              transform: `scale(1, ${scale}) ${textareaValue ? "" : "translate(0, 10px)"}`,
+            }}
             value={textareaValue}
             ref={textareaRef}
             onChange={onTextareaChange}

--- a/editor/src/Config.jsx
+++ b/editor/src/Config.jsx
@@ -23,6 +23,8 @@ const schemas = [
   {key: "fontSize", name: "Font Size", type: "number"},
   {key: "cursive", name: "Cursive", type: "boolean"},
   {key: "padding", name: "Padding", type: "number"},
+  {key: "autoWrap", name: "Auto Wrap", type: "boolean"},
+  {key: "wrapWidth", name: "Wrap Width", type: "number"},
   {key: "word.strokeWidth", name: "Text Stroke Width", type: "number"},
   {key: "word.stroke", name: "Text Stroke", type: "color"},
   {key: "word.fill", name: "Text Fill", type: "color"},

--- a/editor/src/text.js
+++ b/editor/src/text.js
@@ -35,16 +35,26 @@ export function uid() {
   return Math.random().toString(36).substring(2, 15);
 }
 
-export function positionWords(words) {
+export function positionWords(words, {cols = Infinity} = {}) {
   let x = 0;
   let y = 0;
-  for (const word of words) {
+  for (let i = 0; i < words.length; i++) {
+    const word = words[i];
     word.x = x;
     word.y = y;
     x += 1;
     if (word.ch === "\n") {
       y += 1;
       x = 0;
+    } else if (x >= cols) {
+      // Skip the auto-wrap when the next word is an explicit \n — the \n
+      // will break the line in both the SVG and the textarea, so adding
+      // a phantom row here would make them go out of sync.
+      const next = words[i + 1];
+      if (!next || next.ch !== "\n") {
+        y += 1;
+        x = 0;
+      }
     }
   }
   return words;


### PR DESCRIPTION
## Summary

- **Auto-wrap** (issue #38): words now flow to the next row at a configurable max width (`wrapWidth`, default 1000px). Toggle via the new **Auto Wrap** and **Wrap Width** options in the Config panel. When `autoWrap` is off, the original unbounded layout is preserved.
- **Responsive wrap**: the effective wrap width is `min(containerWidth, wrapWidth)`, so the layout reflows in real time as the window is resized.
- **Cursor/selection alignment**: fixed textarea `lineHeight` and `padding` so the selection highlight and text cursor exactly overlay the SVG word cells.
- **Non-content key bug**: pressing arrow keys, Option/Alt, Tab, etc. while text was selected would silently delete the selection. Fixed by ignoring non-content keys early in the keydown handler.
- **Paragraph cursor sync**: when a paragraph ends at exactly `cols` words followed by an explicit `\n`, a phantom auto-wrap row was added in the SVG but not the textarea, causing cursor drift. Fixed in `positionWords`.
- **Scrolling**: the editor div now occupies real layout space (margin instead of position offset) so `overflow: auto` on the container correctly activates a scrollbar. Added 100px minimum top margin (clears the fixed Config button bar) and 200px bottom/right margin for breathing room.

## Test plan

- [x] Type a long sentence — words should wrap at ~1000px (or container width if narrower)
- [x] Toggle Auto Wrap off — layout should return to single unbounded row
- [x] Resize the window — layout should reflow immediately without typing
- [x] Select words with click-drag or Cmd+A — blue highlight should cover each cell fully
- [x] Press arrow keys / Option key with text selected — selection should not be deleted
- [x] Add a blank line between two paragraphs — cursor should stay aligned in both blocks
- [x] Type enough to overflow the viewport — scrollbar should appear; content reachable top and bottom

🤖 Generated with [Claude Code](https://claude.com/claude-code)