### PR TITLE
Fix Japanese font number display off by one

### DIFF
--- a/src/hersheytext.json
+++ b/src/hersheytext.json
@@ -3466,6 +3466,7 @@
   },
   "japanese": {
     "name": "Japanese",
+    "offset": 32,
     "chars": [
       {
         "d": "M4,22 L3,21 4,20 5,21 5,23 4,25 3,26",

--- a/src/text.js
+++ b/src/text.js
@@ -9,7 +9,8 @@ const LAYOUTS = {
 };
 
 function points(key, ch) {
-  const idx = (ch) => ch.charCodeAt(0) - 33;
+  const offset = fonts[key]["offset"] ?? 33;
+  const idx = (ch) => ch.charCodeAt(0) - offset;
   const font = fonts[key]["chars"];
   const path = ch === " " ? "M8,0" : font[idx(ch)]["d"];
   const plines = [];


### PR DESCRIPTION
## Summary

- The `japanese` font's `chars` array starts at ASCII 32 (space), not ASCII 33 like every other font — giving it 192 entries (96 standard + 96 Japanese-specific glyphs) instead of 95
- The hardcoded offset of `33` in `points()` caused all digits to resolve one index too early: displaying `'3'` rendered 二 (2), `'4'` rendered 三 (3), etc.
- Added an optional `"offset"` field to the font definition in `hersheytext.json` (set to `32` for `japanese`) and updated `points()` in `text.js` to read it, defaulting to `33` for all other fonts

Closes #43

## Test plan

- [x] Run the clock app and switch the font to `japanese` — confirm digits match the actual time
- [x] Confirm other fonts (e.g. `futural`, `timesrb`) are unaffected

🤖 Generated with [Claude Code](https://claude.ai/claude-code)