### PR TITLE
Add APack hover tooltips and tighten example modal

### DIFF
--- a/web/components/editor/APack.jsx
+++ b/web/components/editor/APack.jsx
@@ -13,7 +13,7 @@ export function APack({
   tooltip,
 }) {
   const ref = useRef(null);
-  const label = tooltip === false ? null : tooltip ?? (onClick ? text : null);
+  const label = tooltip === false ? null : tooltip ?? text;
 
   useEffect(() => {
     if (ref.current) {
@@ -27,13 +27,13 @@ export function APack({
   return (
     <div
       style={{
-        position: "relative",
         padding: bordered ? "2px" : 0,
         cursor: onClick ? "pointer" : "default",
         border: bordered ? "1.5px solid black" : "none",
         ...style,
+        ...(label ? {position: "relative"} : null),
       }}
-      className={`apack-root${className ? ` ${className}` : ""}`}
+      className={["apack-root", className].filter(Boolean).join(" ")}
       onClick={onClick}
       onMouseEnter={onMouseEnter}
       onMouseLeave={onMouseLeave}

--- a/web/components/editor/APack.jsx
+++ b/web/components/editor/APack.jsx
@@ -10,8 +10,10 @@ export function APack({
   bordered = true,
   style = {},
   className = "",
+  tooltip,
 }) {
   const ref = useRef(null);
+  const label = tooltip === false ? null : tooltip ?? (onClick ? text : null);
 
   useEffect(() => {
     if (ref.current) {
@@ -25,17 +27,23 @@ export function APack({
   return (
     <div
       style={{
+        position: "relative",
         padding: bordered ? "2px" : 0,
         cursor: onClick ? "pointer" : "default",
         border: bordered ? "1.5px solid black" : "none",
         ...style,
       }}
-      className={className}
+      className={`apack-root${className ? ` ${className}` : ""}`}
       onClick={onClick}
       onMouseEnter={onMouseEnter}
       onMouseLeave={onMouseLeave}
     >
       <span ref={ref}></span>
+      {label && (
+        <span className="apack-tooltip" role="tooltip">
+          {label}
+        </span>
+      )}
     </div>
   );
 }

--- a/web/components/editor/App.css
+++ b/web/components/editor/App.css
@@ -144,11 +144,10 @@
   line-height: 1.2;
   white-space: nowrap;
   pointer-events: none;
-  opacity: 0;
+  visibility: hidden;
   z-index: 1100;
 }
 
-.apack-root:hover .apack-tooltip,
-.apack-root:focus-within .apack-tooltip {
-  opacity: 1;
+.apack-root:hover .apack-tooltip {
+  visibility: visible;
 }

--- a/web/components/editor/App.css
+++ b/web/components/editor/App.css
@@ -129,3 +129,26 @@
 .icon-button:hover {
   color: #333;
 }
+
+.apack-tooltip {
+  position: absolute;
+  top: 100%;
+  left: 50%;
+  transform: translateX(-50%);
+  margin-top: 4px;
+  padding: 4px 8px;
+  background: #000;
+  color: #fff;
+  font-family: monospace;
+  font-size: 12px;
+  line-height: 1.2;
+  white-space: nowrap;
+  pointer-events: none;
+  opacity: 0;
+  z-index: 1100;
+}
+
+.apack-root:hover .apack-tooltip,
+.apack-root:focus-within .apack-tooltip {
+  opacity: 1;
+}

--- a/web/components/editor/App.jsx
+++ b/web/components/editor/App.jsx
@@ -588,14 +588,9 @@ function App() {
     <div className="editor-app">
       <div className="editor-top-bar">
         <div className="editor-top-bar-brand">
-          <APack text="APack" cellSize={52} bordered={false} tooltip="APack" />
+          <APack text="APack" cellSize={52} bordered={false} />
           <div className="editor-top-bar-divider" aria-hidden="true" />
-          <APack
-            text="Write English like Chinese"
-            cellSize={52}
-            bordered={false}
-            tooltip="Write English like Chinese"
-          />
+          <APack text="Write English like Chinese" cellSize={52} bordered={false} />
         </div>
 
         <div className="editor-top-bar-actions">

--- a/web/components/editor/App.jsx
+++ b/web/components/editor/App.jsx
@@ -588,9 +588,14 @@ function App() {
     <div className="editor-app">
       <div className="editor-top-bar">
         <div className="editor-top-bar-brand">
-          <APack text="APack" cellSize={52} bordered={false} />
+          <APack text="APack" cellSize={52} bordered={false} tooltip="APack" />
           <div className="editor-top-bar-divider" aria-hidden="true" />
-          <APack text="Write English like Chinese" cellSize={52} bordered={false} />
+          <APack
+            text="Write English like Chinese"
+            cellSize={52}
+            bordered={false}
+            tooltip="Write English like Chinese"
+          />
         </div>
 
         <div className="editor-top-bar-actions">

--- a/web/components/editor/Showcase.css
+++ b/web/components/editor/Showcase.css
@@ -21,15 +21,11 @@
   border: 1.5px solid #000;
 }
 
-.showcase-modal-header {
+.showcase-modal-close {
   position: absolute;
   top: 12px;
   right: 12px;
   z-index: 1;
-  margin: 0;
-}
-
-.showcase-modal-header .icon-button {
   background: none;
   border: none;
   cursor: pointer;
@@ -40,7 +36,7 @@
   padding: 0;
 }
 
-.showcase-modal-header .icon-button:hover {
+.showcase-modal-close:hover {
   color: #333;
 }
 

--- a/web/components/editor/Showcase.css
+++ b/web/components/editor/Showcase.css
@@ -11,6 +11,7 @@
 }
 
 .showcase-modal {
+  position: relative;
   background: #fbf7eb;
   width: min(960px, 100%);
   max-height: min(90vh, 860px);
@@ -21,10 +22,11 @@
 }
 
 .showcase-modal-header {
-  display: flex;
-  justify-content: space-between;
-  align-items: flex-start;
-  margin-bottom: 28px;
+  position: absolute;
+  top: 12px;
+  right: 12px;
+  z-index: 1;
+  margin: 0;
 }
 
 .showcase-modal-header .icon-button {

--- a/web/components/editor/Showcase.jsx
+++ b/web/components/editor/Showcase.jsx
@@ -53,11 +53,9 @@ export function Showcase({onClose, updateTemplate}) {
   return (
     <div className="showcase-modal-backdrop" onClick={onBackdropClick}>
       <div className="showcase-modal" role="dialog" aria-modal="true" aria-label="Example">
-        <div className="showcase-modal-header">
-          <button onClick={onClose} className="icon-button" aria-label="Close example">
-            <FiX size={22} color="#000" />
-          </button>
-        </div>
+        <button onClick={onClose} className="showcase-modal-close" aria-label="Close example">
+          <FiX size={22} color="#000" />
+        </button>
 
         <div className="showcase-modal-body">
           <section className="showcase-section">

--- a/web/components/editor/Showcase.jsx
+++ b/web/components/editor/Showcase.jsx
@@ -54,7 +54,6 @@ export function Showcase({onClose, updateTemplate}) {
     <div className="showcase-modal-backdrop" onClick={onBackdropClick}>
       <div className="showcase-modal" role="dialog" aria-modal="true" aria-label="Example">
         <div className="showcase-modal-header">
-          <APack text="Example" cellSize={40} bordered={false} />
           <button onClick={onClose} className="icon-button" aria-label="Close example">
             <FiX size={22} color="#000" />
           </button>


### PR DESCRIPTION
## Summary
- Add black-box hover tooltips under APack icons that show the plain readable label (toolbar actions, title, and tagline).
- Remove the redundant Example icon from the example modal header and pin the close button so content starts higher.

## Test plan
- [ ] Hover Config / Save / New / Upload / Download / Example / Github and confirm a black tooltip appears below with normal text
- [ ] Hover APack title and “Write English like Chinese” tagline and confirm tooltips appear
- [ ] Open the Example panel and confirm there is no Example icon in the header
- [ ] Confirm the close button still works and top spacing looks tighter
- [ ] Confirm brand marks without an explicit tooltip elsewhere are unchanged


Made with [Cursor](https://cursor.com)