### PR TITLE
Optimize editor for mobile viewports

### DIFF
--- a/web/components/editor/App.css
+++ b/web/components/editor/App.css
@@ -151,3 +151,24 @@
 .apack-root:hover .apack-tooltip {
   visibility: visible;
 }
+
+@media (max-width: 768px) {
+  .editor-top-bar {
+    gap: 8px;
+    padding: 8px 12px;
+  }
+
+  .editor-top-bar-brand {
+    gap: 0;
+  }
+
+  .editor-top-bar-tagline,
+  .editor-top-bar-tools {
+    display: none;
+  }
+
+  .editor-top-bar-actions,
+  .editor-top-bar-group {
+    gap: 8px;
+  }
+}

--- a/web/components/editor/App.css
+++ b/web/components/editor/App.css
@@ -32,7 +32,9 @@
 }
 
 .editor-top-bar-actions,
-.editor-top-bar-group {
+.editor-top-bar-group,
+.editor-top-bar-tagline,
+.editor-top-bar-tools {
   display: flex;
   align-items: center;
   gap: 12px;
@@ -156,10 +158,6 @@
   .editor-top-bar {
     gap: 8px;
     padding: 8px 12px;
-  }
-
-  .editor-top-bar-brand {
-    gap: 0;
   }
 
   .editor-top-bar-tagline,

--- a/web/components/editor/App.jsx
+++ b/web/components/editor/App.jsx
@@ -589,13 +589,15 @@ function App() {
       <div className="editor-top-bar">
         <div className="editor-top-bar-brand">
           <APack text="APack" cellSize={52} bordered={false} />
-          <div className="editor-top-bar-divider" aria-hidden="true" />
-          <APack text="Write English like Chinese" cellSize={52} bordered={false} />
+          <div className="editor-top-bar-divider editor-top-bar-tagline" aria-hidden="true" />
+          <div className="editor-top-bar-tagline">
+            <APack text="Write English like Chinese" cellSize={52} bordered={false} />
+          </div>
         </div>
 
         <div className="editor-top-bar-actions">
           {!hideConfig && (
-            <div className="editor-top-bar-group">
+            <div className="editor-top-bar-group editor-top-bar-tools">
               <APack text="Config" cellSize={40} onClick={() => setShowConfig(true)} />
               <APack text="Save" cellSize={40} onClick={onSave} />
               <APack text="New" cellSize={40} onClick={onNew} />
@@ -609,7 +611,9 @@ function App() {
               )}
             </div>
           )}
-          {!hideConfig && <div className="editor-top-bar-divider" aria-hidden="true" />}
+          {!hideConfig && (
+            <div className="editor-top-bar-divider editor-top-bar-tools" aria-hidden="true" />
+          )}
           <div className="editor-top-bar-group">
             <APack text="Example" cellSize={40} onClick={() => setShowShowcase(true)} />
             {!hideConfig && <APack text="Github" cellSize={40} onClick={onOpenGithub} />}

--- a/web/components/editor/App.jsx
+++ b/web/components/editor/App.jsx
@@ -589,30 +589,30 @@ function App() {
       <div className="editor-top-bar">
         <div className="editor-top-bar-brand">
           <APack text="APack" cellSize={52} bordered={false} />
-          <div className="editor-top-bar-divider editor-top-bar-tagline" aria-hidden="true" />
           <div className="editor-top-bar-tagline">
+            <div className="editor-top-bar-divider" aria-hidden="true" />
             <APack text="Write English like Chinese" cellSize={52} bordered={false} />
           </div>
         </div>
 
         <div className="editor-top-bar-actions">
           {!hideConfig && (
-            <div className="editor-top-bar-group editor-top-bar-tools">
-              <APack text="Config" cellSize={40} onClick={() => setShowConfig(true)} />
-              <APack text="Save" cellSize={40} onClick={onSave} />
-              <APack text="New" cellSize={40} onClick={onNew} />
-              <APack text="Upload" cellSize={40} onClick={onUpload} />
-              <APack text="Download" cellSize={40} onClick={onDownload} />
-              {textareaValue && (
-                <>
-                  <APack text="PNG" cellSize={40} onClick={onDownloadPNG} />
-                  <APack text="SVG" cellSize={40} onClick={onDownloadSVG} />
-                </>
-              )}
+            <div className="editor-top-bar-tools">
+              <div className="editor-top-bar-group">
+                <APack text="Config" cellSize={40} onClick={() => setShowConfig(true)} />
+                <APack text="Save" cellSize={40} onClick={onSave} />
+                <APack text="New" cellSize={40} onClick={onNew} />
+                <APack text="Upload" cellSize={40} onClick={onUpload} />
+                <APack text="Download" cellSize={40} onClick={onDownload} />
+                {textareaValue && (
+                  <>
+                    <APack text="PNG" cellSize={40} onClick={onDownloadPNG} />
+                    <APack text="SVG" cellSize={40} onClick={onDownloadSVG} />
+                  </>
+                )}
+              </div>
+              <div className="editor-top-bar-divider" aria-hidden="true" />
             </div>
-          )}
-          {!hideConfig && (
-            <div className="editor-top-bar-divider editor-top-bar-tools" aria-hidden="true" />
           )}
           <div className="editor-top-bar-group">
             <APack text="Example" cellSize={40} onClick={() => setShowShowcase(true)} />

--- a/web/components/editor/Showcase.css
+++ b/web/components/editor/Showcase.css
@@ -98,10 +98,6 @@
     max-height: 92vh;
   }
 
-  .showcase-modal-header {
-    margin-bottom: 20px;
-  }
-
   .showcase-modal-body {
     gap: 24px;
   }

--- a/web/components/editor/Showcase.css
+++ b/web/components/editor/Showcase.css
@@ -87,3 +87,26 @@
   flex-wrap: wrap;
   gap: 12px;
 }
+
+@media (max-width: 768px) {
+  .showcase-modal-backdrop {
+    padding: 12px;
+  }
+
+  .showcase-modal {
+    padding: 16px;
+    max-height: 92vh;
+  }
+
+  .showcase-modal-header {
+    margin-bottom: 20px;
+  }
+
+  .showcase-modal-body {
+    gap: 24px;
+  }
+
+  .showcase-editor-grid {
+    grid-template-columns: 1fr;
+  }
+}

--- a/web/components/editor/Showcase.jsx
+++ b/web/components/editor/Showcase.jsx
@@ -59,7 +59,7 @@ export function Showcase({onClose, updateTemplate}) {
 
         <div className="showcase-modal-body">
           <section className="showcase-section">
-            <h2 className="showcase-section-title">Editor examples</h2>
+            <h2 className="showcase-section-title">Templates</h2>
             <div className="showcase-editor-grid">
               {Object.entries(templates).map(([key, template]) => (
                 <Item key={key} config={template} onClick={() => onSelectTemplate(key)} />
@@ -68,7 +68,7 @@ export function Showcase({onClose, updateTemplate}) {
           </section>
 
           <section className="showcase-section">
-            <h2 className="showcase-section-title">External examples</h2>
+            <h2 className="showcase-section-title">Made with APack</h2>
             <div className="showcase-external-grid">
               {EXTERNAL_EXAMPLES.map((project) => (
                 <APack

--- a/web/components/editor/Showcase.jsx
+++ b/web/components/editor/Showcase.jsx
@@ -52,8 +52,8 @@ export function Showcase({onClose, updateTemplate}) {
 
   return (
     <div className="showcase-modal-backdrop" onClick={onBackdropClick}>
-      <div className="showcase-modal" role="dialog" aria-modal="true" aria-label="Example">
-        <button onClick={onClose} className="showcase-modal-close" aria-label="Close example">
+      <div className="showcase-modal" role="dialog" aria-modal="true" aria-label="Examples">
+        <button onClick={onClose} className="showcase-modal-close" aria-label="Close examples">
           <FiX size={22} color="#000" />
         </button>
 


### PR DESCRIPTION
## Summary
- On mobile (≤768px), show only APack branding plus Example and Github; hide the tagline and Config/Save/New/Upload/Download tools
- Stack template previews in a single column in the examples modal, keep Made with APack projects in a row
- Rename section titles to Templates and Made with APack

## Test plan
- [ ] Open the editor on a narrow viewport (or Chrome DevTools mobile) and confirm top bar shows APack, Example, and Github only
- [ ] Confirm desktop top bar is unchanged (tagline + all tools)
- [ ] Open examples modal on mobile: templates are one column; Tree/AClock/Sticker stay square and in a row
- [ ] Confirm section titles read Templates and Made with APack


Made with [Cursor](https://cursor.com)