### PR TITLE
Restyle AClock with cream cards and featured Local/UTC layout

### DIFF
--- a/web/app/aclock/[[...slug]]/page.tsx
+++ b/web/app/aclock/[[...slug]]/page.tsx
@@ -1,7 +1,22 @@
 import AClockPageClient from "./AClockPageClient";
+import {timezoneToCityName} from "../../../components/aclock/utils.js";
 
 export function generateStaticParams() {
-  return [{slug: []}];
+  const params: {slug: string[]}[] = [{slug: []}, {slug: ["local"]}, {slug: ["utc"]}];
+  const seen = new Set(["local", "utc"]);
+
+  try {
+    for (const tz of Intl.supportedValuesOf("timeZone")) {
+      const city = timezoneToCityName(tz);
+      if (!city || seen.has(city)) continue;
+      seen.add(city);
+      params.push({slug: [city]});
+    }
+  } catch {
+    // Intl.supportedValuesOf may be unavailable in some environments
+  }
+
+  return params;
 }
 
 export default function AClockPage() {

--- a/web/app/aclock/aclock.css
+++ b/web/app/aclock/aclock.css
@@ -4,26 +4,52 @@
 
 /* Scoped to /aclock only — plain CSS so it wins over global resets */
 .aclock-root {
+  --aclock-cream: #fbf7f0;
+  --aclock-ink: #2c2416;
+  --aclock-muted: #8a7f70;
+  --aclock-card: #fefcf8;
+  --aclock-border: #e4ddd2;
+  --aclock-serif: ui-serif, Georgia, Cambria, "Times New Roman", Times, serif;
+  --aclock-sans: ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto,
+    Helvetica, Arial, sans-serif;
+
   box-sizing: border-box;
   min-height: 100vh;
   width: 100%;
-  background: #fff;
-  color: #1b1e23;
-  padding: 2rem 2.5rem 4rem;
-  font-family: ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto,
-    Helvetica, Arial, sans-serif;
+  background: var(--aclock-cream);
+  color: var(--aclock-ink);
+  padding: 2.75rem 1.5rem 4rem;
+  font-family: var(--aclock-sans);
   -webkit-font-smoothing: antialiased;
+}
+
+.aclock-root:has(.aclock-watch-page) {
+  height: 100vh;
+  height: 100dvh;
+  min-height: 0;
+  overflow: hidden;
+  padding: 1.5rem;
+  display: flex;
+  flex-direction: column;
 }
 
 @media (min-width: 768px) {
   .aclock-root {
-    padding: 2.5rem 3.5rem 4rem;
+    padding: 3.25rem 2.5rem 4rem;
+  }
+
+  .aclock-root:has(.aclock-watch-page) {
+    padding: 2rem 2.5rem;
   }
 }
 
 @media (min-width: 1024px) {
   .aclock-root {
-    padding: 3rem 4rem 5rem;
+    padding: 3.75rem 3.5rem 5rem;
+  }
+
+  .aclock-root:has(.aclock-watch-page) {
+    padding: 2rem 3.5rem;
   }
 }
 
@@ -31,34 +57,88 @@
   color: inherit;
 }
 
-.aclock-root h1 a {
-  text-decoration: underline;
-  text-underline-offset: 2px;
+.aclock-header {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 1.25rem;
+  text-align: left;
+  margin-bottom: 2.25rem;
 }
 
-.aclock-root h1 a:hover {
-  color: #374151;
+@media (min-width: 768px) {
+  .aclock-header {
+    flex-direction: row;
+    align-items: flex-start;
+    justify-content: space-between;
+    gap: 2rem;
+    margin-bottom: 2.75rem;
+  }
+}
+
+.aclock-header-copy {
+  min-width: 0;
+}
+
+.aclock-eyebrow {
+  display: block;
+  margin: 0 0 0.85rem;
+  font-size: 0.6875rem;
+  font-weight: 500;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  color: var(--aclock-muted);
 }
 
 .aclock-root h1 {
-  font-family: ui-serif, Georgia, Cambria, "Times New Roman", Times, serif;
-  margin-bottom: 1.25rem;
-  text-align: center;
-  font-size: 1.5rem;
+  font-family: var(--aclock-serif);
+  margin: 0;
+  text-align: left;
+  font-size: 2.25rem;
+  font-weight: 700;
+  font-style: italic;
+  letter-spacing: -0.02em;
+  line-height: 1.15;
+  color: var(--aclock-ink);
+}
+
+.aclock-root h1 .aclock-title-by {
   font-weight: 400;
+  font-style: normal;
+  color: #6b6358;
+}
+
+.aclock-root h1 a {
+  text-decoration: none;
+}
+
+.aclock-root h1 a:hover {
+  opacity: 0.75;
 }
 
 @media (min-width: 768px) {
   .aclock-root h1 {
-    margin-bottom: 1.5rem;
-    font-size: 1.875rem;
+    font-size: 2.75rem;
   }
 }
 
 @media (min-width: 1024px) {
   .aclock-root h1 {
-    margin-bottom: 1.75rem;
-    font-size: 2.25rem;
+    font-size: 3.25rem;
+  }
+}
+
+.aclock-legend {
+  display: flex;
+  justify-content: flex-start;
+  align-items: flex-start;
+  flex-shrink: 0;
+}
+
+@media (min-width: 768px) {
+  .aclock-legend {
+    justify-content: flex-end;
+    padding-top: 0.25rem;
   }
 }
 
@@ -68,21 +148,89 @@
 
 @media (min-width: 768px) {
   .aclock-toolbar {
-    margin-bottom: 2.25rem;
-  }
-}
-
-@media (min-width: 1024px) {
-  .aclock-toolbar {
     margin-bottom: 2.5rem;
   }
 }
 
-.aclock-grid {
-  display: grid;
-  width: 100%;
+.aclock-toolbar-inner {
+  display: flex;
+  flex-direction: column;
   gap: 0.875rem;
-  grid-template-columns: repeat(auto-fill, minmax(150px, 1fr));
+  align-items: stretch;
+}
+
+@media (min-width: 768px) {
+  .aclock-toolbar-inner {
+    flex-direction: row;
+    flex-wrap: wrap;
+    align-items: center;
+    gap: 0.875rem 1.25rem;
+  }
+}
+
+.aclock-toolbar-controls {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 0.75rem 1.125rem;
+  flex: 1;
+  min-width: 0;
+}
+
+.aclock-toolbar-menu {
+  display: none;
+  background: none;
+  border: none;
+  cursor: pointer;
+  color: var(--aclock-ink);
+  padding: 0.25rem;
+}
+
+.aclock-toolbar-menu:hover {
+  opacity: 0.7;
+}
+
+@media (max-width: 767px) {
+  .aclock-toolbar-menu {
+    display: block;
+    align-self: flex-start;
+  }
+
+  .aclock-toolbar-controls {
+    display: none;
+    width: 100%;
+  }
+
+  .aclock-toolbar-controls.is-open {
+    display: flex;
+  }
+}
+
+.aclock-zone-count {
+  margin: 0;
+  font-size: 0.8125rem;
+  color: var(--aclock-muted);
+  white-space: nowrap;
+  margin-left: auto;
+}
+
+.aclock-toolbar-rule {
+  margin-top: 1.35rem;
+  border: none;
+  border-top: 1px solid var(--aclock-border);
+  height: 0;
+}
+
+.aclock-sr-only {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
 }
 
 .aclock-field {
@@ -90,106 +238,339 @@
   flex-direction: column;
 }
 
+.aclock-field-search {
+  flex: 1 1 14rem;
+  min-width: 12rem;
+  max-width: 22rem;
+}
+
+.aclock-field-inline {
+  flex-direction: row;
+  align-items: center;
+  gap: 0.5rem;
+}
+
 .aclock-field label {
-  margin-bottom: 0.25rem;
-  font-size: 0.75rem;
-  color: #4b5563;
+  margin-bottom: 0.35rem;
+  font-size: 0.8125rem;
+  font-weight: 400;
+  letter-spacing: 0;
+  text-transform: none;
+  color: var(--aclock-muted);
+  white-space: nowrap;
+}
+
+.aclock-field-inline label {
+  margin-bottom: 0;
 }
 
 .aclock-input,
 .aclock-select {
   box-sizing: border-box;
-  padding: 0.375rem 0.75rem;
+  padding: 0.5rem 0.975rem;
   font-size: 0.875rem;
   line-height: 1.25;
-  color: #1f2937;
-  background: #fff;
-  border: 1px solid #d1d5db;
-  border-radius: 0.5rem;
-  min-height: 2rem;
+  color: var(--aclock-ink);
+  background: var(--aclock-card);
+  border: 1px solid var(--aclock-border);
+  border-radius: 9999px;
+  min-height: 2.35rem;
+}
+
+.aclock-input::placeholder {
+  color: #b0a79a;
 }
 
 .aclock-input:focus,
 .aclock-select:focus {
   outline: none;
-  box-shadow: 0 0 0 2px #3b82f6;
+  border-color: #c4b8a8;
+  box-shadow: 0 0 0 2px rgba(44, 36, 22, 0.08);
 }
 
 .aclock-search {
-  min-width: 11.25rem;
+  width: 100%;
+  min-width: 0;
+}
+
+.aclock-featured-row {
+  display: grid;
+  width: 100%;
+  gap: 1rem;
+  margin-bottom: 1.5rem;
+  grid-template-columns: 1fr;
+}
+
+@media (min-width: 768px) {
+  .aclock-featured-row {
+    gap: 1.25rem;
+    margin-bottom: 1.75rem;
+    grid-template-columns: 1fr 1fr;
+  }
+}
+
+@media (min-width: 1024px) {
+  .aclock-featured-row {
+    gap: 1.5rem;
+    margin-bottom: 2rem;
+  }
+}
+
+.aclock-grid {
+  display: grid;
+  width: 100%;
+  gap: 1rem;
+  grid-template-columns: repeat(auto-fill, minmax(140px, 1fr));
+}
+
+@media (min-width: 640px) {
+  .aclock-grid {
+    gap: 1.125rem;
+    grid-template-columns: repeat(auto-fill, minmax(150px, 1fr));
+  }
+}
+
+@media (min-width: 1024px) {
+  .aclock-grid {
+    gap: 1.25rem;
+    grid-template-columns: repeat(6, 1fr);
+  }
+}
+
+.aclock-card {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  width: 100%;
+  height: 100%;
+  box-sizing: border-box;
+  padding: 1.25rem 1rem 1.125rem;
+  background: var(--aclock-card);
+  border: 1px solid var(--aclock-border);
+  border-radius: 1.25rem;
+  cursor: pointer;
+  transition: border-color 0.15s ease, box-shadow 0.15s ease;
+}
+
+.aclock-card:hover {
+  border-color: #d4c9ba;
+  box-shadow: 0 4px 16px rgba(44, 36, 22, 0.06);
+}
+
+.aclock-card.is-static {
+  cursor: default;
+}
+
+.aclock-card.is-featured {
+  flex-direction: row;
+  align-items: center;
+  gap: 1.25rem;
+  padding: 1.25rem 1.5rem;
+  min-height: 10rem;
+}
+
+.aclock-card-face {
+  width: 100%;
+  max-width: 9rem;
+  position: relative;
+  padding-top: 100%;
+  border-radius: 0.65rem;
+  overflow: hidden;
+  flex-shrink: 0;
+}
+
+.aclock-card.is-featured .aclock-card-face {
+  width: 7rem;
+  max-width: 7rem;
+  padding-top: 7rem;
+}
+
+@media (min-width: 768px) {
+  .aclock-card.is-featured .aclock-card-face {
+    width: 8.5rem;
+    max-width: 8.5rem;
+    padding-top: 8.5rem;
+  }
+}
+
+.aclock-card-face-inner {
+  position: absolute;
+  inset: 0;
+  width: 100%;
+  height: 100%;
+}
+
+.aclock-card-face.is-fixed {
+  padding-top: 0;
+  width: var(--aclock-face-size, 150px);
+  height: var(--aclock-face-size, 150px);
+  max-width: none;
+}
+
+.aclock-card-meta {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  width: 100%;
+  margin-top: 1rem;
+  gap: 0.2rem;
+  min-width: 0;
+}
+
+.aclock-card-meta-featured {
+  align-items: flex-start;
+  margin-top: 0;
+  gap: 0.35rem;
+  flex: 1;
+}
+
+.aclock-card-eyebrow {
+  margin: 0;
+  font-size: 0.6875rem;
+  font-weight: 500;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  color: var(--aclock-muted);
+}
+
+.aclock-card-name {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.35rem;
+  width: 100%;
+  margin: 0;
+  padding: 0;
+  border: none;
+  background: none;
+  font-family: var(--aclock-serif);
+  font-size: 1rem;
+  font-weight: 700;
+  line-height: 1.25;
+  color: var(--aclock-ink);
+  text-align: center;
+  text-decoration: none;
+  white-space: nowrap;
+  text-overflow: ellipsis;
+  overflow: hidden;
+  cursor: pointer;
+}
+
+.aclock-card-flag {
+  flex-shrink: 0;
+  font-style: normal;
+  font-family: var(--aclock-sans);
+  line-height: 1;
+}
+
+.aclock-card-meta-featured .aclock-card-name {
+  justify-content: flex-start;
+  text-align: left;
+  font-size: 1.25rem;
+  font-weight: 600;
+  white-space: normal;
+}
+
+@media (min-width: 768px) {
+  .aclock-card-meta-featured .aclock-card-name {
+    font-size: 1.375rem;
+  }
+}
+
+.aclock-card-name:hover {
+  opacity: 0.75;
+}
+
+.aclock-card-offset {
+  margin: 0;
+  font-size: 0.75rem;
+  font-weight: 400;
+  color: var(--aclock-muted);
+  text-align: center;
+  letter-spacing: 0.02em;
+}
+
+.aclock-card-meta-featured .aclock-card-offset {
+  text-align: left;
+  font-size: 0.8125rem;
 }
 
 .aclock-watch-page {
-  min-height: 100%;
+  flex: 1;
   width: 100%;
+  min-height: 0;
   display: flex;
   flex-direction: column;
   align-items: center;
   justify-content: center;
+  overflow: hidden;
 }
 
-.aclock-watch-inner {
+.aclock-watch-detail {
   display: flex;
-  flex-direction: column;
   align-items: center;
-  justify-content: center;
+  gap: 1rem;
   width: 100%;
   max-width: 28rem;
 }
 
-.aclock-watch-header {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  width: 100%;
-  margin-bottom: 2rem;
+@media (min-width: 768px) {
+  .aclock-watch-detail {
+    gap: 1.25rem;
+    max-width: 32rem;
+  }
 }
 
-.aclock-watch-center {
-  display: flex;
-  align-items: center;
-  justify-content: center;
+.aclock-watch-detail-card {
+  flex: 1;
+  min-width: 0;
 }
 
-.aclock-watch-preview {
-  margin-bottom: 2rem;
+.aclock-watch-detail-card .aclock-card {
+  cursor: default;
+}
+
+.aclock-watch-detail-card .aclock-card.is-featured {
+  min-height: 9rem;
 }
 
 .aclock-watch-error {
-  text-align: center;
+  text-align: left;
 }
 
 .aclock-watch-error h1 {
-  margin-bottom: 1rem;
+  margin: 0 0 0.75rem;
   font-size: 1.5rem;
   font-weight: 600;
+  font-style: normal;
 }
 
 .aclock-icon-button {
   background: none;
   border: none;
   cursor: pointer;
-  color: #4b5563;
-  padding: 0.25rem;
+  color: var(--aclock-muted);
+  padding: 0.35rem;
+  flex-shrink: 0;
   transition: color 0.15s ease;
 }
 
 .aclock-icon-button:hover {
-  color: #1f2937;
+  color: var(--aclock-ink);
 }
 
 .aclock-text-button {
   background: none;
   border: none;
   cursor: pointer;
-  color: #2563eb;
+  color: var(--aclock-ink);
   font-size: inherit;
   text-decoration: underline;
   text-underline-offset: 2px;
 }
 
 .aclock-text-button:hover {
-  color: #1d4ed8;
+  opacity: 0.75;
 }
 
 .aclock-watch-location {
@@ -198,9 +579,10 @@
   gap: 0.5rem;
   color: inherit;
   text-decoration: none;
+  font-family: var(--aclock-serif);
+  font-weight: 700;
 }
 
 .aclock-watch-location:hover {
-  color: #374151;
+  opacity: 0.75;
 }
-

--- a/web/app/aclock/aclock.css
+++ b/web/app/aclock/aclock.css
@@ -24,6 +24,7 @@
 }
 
 .aclock-root:has(.aclock-watch-page) {
+  position: relative;
   height: 100vh;
   height: 100dvh;
   min-height: 0;
@@ -499,23 +500,37 @@
   overflow: hidden;
 }
 
+.aclock-watch-home {
+  position: absolute;
+  top: 1.25rem;
+  left: 1.25rem;
+  z-index: 1;
+}
+
+@media (min-width: 768px) {
+  .aclock-watch-home {
+    top: 1.5rem;
+    left: 1.5rem;
+  }
+}
+
 .aclock-watch-detail {
   display: flex;
   align-items: center;
-  gap: 1rem;
+  justify-content: center;
   width: 100%;
   max-width: 28rem;
 }
 
 @media (min-width: 768px) {
   .aclock-watch-detail {
-    gap: 1.25rem;
     max-width: 32rem;
   }
 }
 
 .aclock-watch-detail-card {
   flex: 1;
+  width: 100%;
   min-width: 0;
 }
 

--- a/web/app/aclock/aclock.css
+++ b/web/app/aclock/aclock.css
@@ -400,13 +400,6 @@
   height: 100%;
 }
 
-.aclock-card-face.is-fixed {
-  padding-top: 0;
-  width: var(--aclock-face-size, 150px);
-  height: var(--aclock-face-size, 150px);
-  max-width: none;
-}
-
 .aclock-card-meta {
   display: flex;
   flex-direction: column;
@@ -570,19 +563,5 @@
 }
 
 .aclock-text-button:hover {
-  opacity: 0.75;
-}
-
-.aclock-watch-location {
-  display: flex;
-  align-items: center;
-  gap: 0.5rem;
-  color: inherit;
-  text-decoration: none;
-  font-family: var(--aclock-serif);
-  font-weight: 700;
-}
-
-.aclock-watch-location:hover {
   opacity: 0.75;
 }

--- a/web/components/aclock/HomePage.jsx
+++ b/web/components/aclock/HomePage.jsx
@@ -204,7 +204,7 @@ export default function HomePage() {
             timeZone={null}
             featured
             interpolator={interpolators[interpolatorOption]}
-            font={fontOption === "random" ? fontAssignments?.["local"] || "futural" : fontOption}
+            font={fontOption === "random" ? fontAssignments["local"] : fontOption}
             onClick={() => router.push("/aclock/local/")}
           />
           <Watch
@@ -212,7 +212,7 @@ export default function HomePage() {
             timeZone="UTC"
             featured
             interpolator={interpolators[interpolatorOption]}
-            font={fontOption === "random" ? fontAssignments?.["UTC"] || "futural" : fontOption}
+            font={fontOption === "random" ? fontAssignments["UTC"] : fontOption}
             onClick={() => router.push("/aclock/utc/")}
           />
         </div>
@@ -224,7 +224,7 @@ export default function HomePage() {
             key={tz}
             timeZone={tz}
             interpolator={interpolators[interpolatorOption]}
-            font={fontOption === "random" ? fontAssignments?.[tz] || "futural" : fontOption}
+            font={fontOption === "random" ? fontAssignments[tz] : fontOption}
             onClick={() => router.push(`/aclock/${timezoneToCityName(tz)}/`)}
           />
         ))}

--- a/web/components/aclock/HomePage.jsx
+++ b/web/components/aclock/HomePage.jsx
@@ -168,13 +168,20 @@ export default function HomePage() {
 
   return (
     <div className="min-h-full w-full overflow-auto">
-      <h1>
-        <a href="https://github.com/pearmini/apack/tree/main/web" target="_blank" rel="noopener noreferrer">
-          World Clocks
-        </a>{" "}
-        by{" "}
-        <a href="/">APack</a>
-      </h1>
+      <header className="aclock-header">
+        <div className="aclock-header-copy">
+          <p className="aclock-eyebrow">Time zones, wherever you are</p>
+          <h1>
+            <a href="https://github.com/pearmini/apack/tree/main/web" target="_blank" rel="noopener noreferrer">
+              World Clocks
+            </a>{" "}
+            <span className="aclock-title-by">
+              by <a href="/">APack</a>
+            </span>
+          </h1>
+        </div>
+        <div ref={legendRef} className="aclock-legend" />
+      </header>
       <Toolbar
         searchQuery={searchQuery}
         setSearchQuery={setSearchQuery}
@@ -187,28 +194,31 @@ export default function HomePage() {
         interpolators={interpolators}
         validFonts={VALID_FONTS}
         handleReset={handleReset}
-        legendRef={legendRef}
+        zoneCount={filteredTimeZones.length}
       />
 
-      <div className="aclock-grid">
-        {!debouncedSearchQuery.trim() && (
+      {!debouncedSearchQuery.trim() && (
+        <div className="aclock-featured-row">
           <Watch
             key="local"
             timeZone={null}
+            featured
             interpolator={interpolators[interpolatorOption]}
             font={fontOption === "random" ? fontAssignments?.["local"] || "futural" : fontOption}
             onClick={() => router.push("/aclock/local/")}
           />
-        )}
-        {!debouncedSearchQuery.trim() && (
           <Watch
             key="UTC"
             timeZone="UTC"
+            featured
             interpolator={interpolators[interpolatorOption]}
             font={fontOption === "random" ? fontAssignments?.["UTC"] || "futural" : fontOption}
             onClick={() => router.push("/aclock/utc/")}
           />
-        )}
+        </div>
+      )}
+
+      <div className="aclock-grid">
         {filteredTimeZones.map((tz) => (
           <Watch
             key={tz}

--- a/web/components/aclock/Toolbar.jsx
+++ b/web/components/aclock/Toolbar.jsx
@@ -1,13 +1,5 @@
 import {useState} from "react";
 
-const SORT_LABELS = {
-  random: "Random",
-  "alphabet-asc": "A–Z",
-  "alphabet-desc": "Z–A",
-  "time-asc": "By time",
-  "time-desc": "By time ↓",
-};
-
 export default function Toolbar({
   searchQuery,
   setSearchQuery,
@@ -71,14 +63,10 @@ export default function Toolbar({
               value={sortOption}
               onChange={(e) => {
                 const value = e.target.value;
-                if (value === "reset") {
-                  handleReset();
-                } else {
-                  setSortOption(value);
-                }
+                if (value === "reset") handleReset();
+                else setSortOption(value);
               }}
               className="aclock-select"
-              aria-label={`Sort: ${SORT_LABELS[sortOption] || sortOption}`}
             >
               <option value="time-asc">By time</option>
               <option value="time-desc">By time ↓</option>
@@ -96,11 +84,8 @@ export default function Toolbar({
               value={fontOption}
               onChange={(e) => {
                 const value = e.target.value;
-                if (value === "reset") {
-                  handleReset();
-                } else {
-                  setFontOption(value);
-                }
+                if (value === "reset") handleReset();
+                else setFontOption(value);
               }}
               className="aclock-select"
             >
@@ -121,11 +106,8 @@ export default function Toolbar({
               value={interpolatorOption}
               onChange={(e) => {
                 const value = e.target.value;
-                if (value === "reset") {
-                  handleReset();
-                } else {
-                  setInterpolatorOption(value);
-                }
+                if (value === "reset") handleReset();
+                else setInterpolatorOption(value);
               }}
               className="aclock-select"
             >
@@ -141,11 +123,9 @@ export default function Toolbar({
           </div>
         </div>
 
-        {typeof zoneCount === "number" && (
-          <p className="aclock-zone-count">
-            {zoneCount} time zone{zoneCount === 1 ? "" : "s"}
-          </p>
-        )}
+        <p className="aclock-zone-count">
+          {zoneCount} time zone{zoneCount === 1 ? "" : "s"}
+        </p>
       </div>
       <div className="aclock-toolbar-rule" aria-hidden="true" />
     </div>

--- a/web/components/aclock/Toolbar.jsx
+++ b/web/components/aclock/Toolbar.jsx
@@ -1,5 +1,13 @@
 import {useState} from "react";
 
+const SORT_LABELS = {
+  random: "Random",
+  "alphabet-asc": "A–Z",
+  "alphabet-desc": "Z–A",
+  "time-asc": "By time",
+  "time-desc": "By time ↓",
+};
+
 export default function Toolbar({
   searchQuery,
   setSearchQuery,
@@ -12,17 +20,19 @@ export default function Toolbar({
   interpolators,
   validFonts,
   handleReset,
-  legendRef,
+  zoneCount,
 }) {
   const [isOpen, setIsOpen] = useState(false);
 
   return (
     <div className="aclock-toolbar">
-      <div className="flex justify-between items-start lg:flex-row flex-col">
+      <div className="aclock-toolbar-inner">
         <button
+          type="button"
           onClick={() => setIsOpen(!isOpen)}
-          className="lg:hidden text-gray-700 hover:bg-gray-100 transition-colors"
+          className="aclock-toolbar-menu"
           aria-label="Toggle menu"
+          aria-expanded={isOpen}
         >
           <svg
             className="w-6 h-6"
@@ -39,24 +49,75 @@ export default function Toolbar({
           </svg>
         </button>
 
-        <div
-          className={`${
-            isOpen ? "flex" : "hidden"
-          } lg:flex flex-wrap items-end gap-4 sm:gap-6 w-full lg:w-auto mt-4 lg:mt-0`}
-        >
-          <div className="aclock-field">
-            <label>Search</label>
+        <div className={`aclock-toolbar-controls${isOpen ? " is-open" : ""}`}>
+          <div className="aclock-field aclock-field-search">
+            <label htmlFor="aclock-search" className="aclock-sr-only">
+              Search
+            </label>
             <input
+              id="aclock-search"
               type="text"
-              placeholder="Search timezones..."
+              placeholder="Search cities or time zones..."
               value={searchQuery}
               onChange={(e) => setSearchQuery(e.target.value)}
               className="aclock-input aclock-search"
             />
           </div>
-          <div className="aclock-field">
-            <label>Color</label>
+
+          <div className="aclock-field aclock-field-inline">
+            <label htmlFor="aclock-sort">Sort</label>
             <select
+              id="aclock-sort"
+              value={sortOption}
+              onChange={(e) => {
+                const value = e.target.value;
+                if (value === "reset") {
+                  handleReset();
+                } else {
+                  setSortOption(value);
+                }
+              }}
+              className="aclock-select"
+              aria-label={`Sort: ${SORT_LABELS[sortOption] || sortOption}`}
+            >
+              <option value="time-asc">By time</option>
+              <option value="time-desc">By time ↓</option>
+              <option value="alphabet-asc">A–Z</option>
+              <option value="alphabet-desc">Z–A</option>
+              <option value="random">Random</option>
+              <option value="reset">Reset</option>
+            </select>
+          </div>
+
+          <div className="aclock-field aclock-field-inline">
+            <label htmlFor="aclock-digits">Digits</label>
+            <select
+              id="aclock-digits"
+              value={fontOption}
+              onChange={(e) => {
+                const value = e.target.value;
+                if (value === "reset") {
+                  handleReset();
+                } else {
+                  setFontOption(value);
+                }
+              }}
+              className="aclock-select"
+            >
+              <option value="reset">Reset</option>
+              <option value="random">Random</option>
+              {validFonts.map((font) => (
+                <option key={font} value={font}>
+                  {font}
+                </option>
+              ))}
+            </select>
+          </div>
+
+          <div className="aclock-field aclock-field-inline">
+            <label htmlFor="aclock-color">Color</label>
+            <select
+              id="aclock-color"
               value={interpolatorOption}
               onChange={(e) => {
                 const value = e.target.value;
@@ -78,55 +139,15 @@ export default function Toolbar({
                 ))}
             </select>
           </div>
-          <div className="aclock-field">
-            <label>Font</label>
-            <select
-              value={fontOption}
-              onChange={(e) => {
-                const value = e.target.value;
-                if (value === "reset") {
-                  handleReset();
-                } else {
-                  setFontOption(value);
-                }
-              }}
-              className="aclock-select"
-            >
-              <option value="reset">Reset</option>
-              <option value="random">Random</option>
-              {validFonts.map((font) => (
-                <option key={font} value={font}>
-                  {font}
-                </option>
-              ))}
-            </select>
-          </div>
-          <div className="aclock-field">
-            <label>Sort</label>
-            <select
-              value={sortOption}
-              onChange={(e) => {
-                const value = e.target.value;
-                if (value === "reset") {
-                  handleReset();
-                } else {
-                  setSortOption(value);
-                }
-              }}
-              className="aclock-select"
-            >
-              <option value="random">Random</option>
-              <option value="alphabet-asc">Alphabet (A-Z)</option>
-              <option value="alphabet-desc">Alphabet (Z-A)</option>
-              <option value="time-asc">Time (Earliest First)</option>
-              <option value="time-desc">Time (Latest First)</option>
-              <option value="reset">Reset</option>
-            </select>
-          </div>
         </div>
 
-        <div ref={legendRef} className="hidden lg:flex justify-start"></div>
+        {typeof zoneCount === "number" && (
+          <p className="aclock-zone-count">
+            {zoneCount} time zone{zoneCount === 1 ? "" : "s"}
+          </p>
+        )}
       </div>
+      <div className="aclock-toolbar-rule" aria-hidden="true" />
     </div>
   );
 }

--- a/web/components/aclock/Watch.jsx
+++ b/web/components/aclock/Watch.jsx
@@ -1,13 +1,12 @@
-import {useRef, useEffect, useState} from "react";
+import {useRef, useEffect, useState, useMemo} from "react";
 import * as apack from "apackjs";
 import * as d3 from "d3";
-import {MapPin} from "lucide-react";
 import {getFlagEmoji, getCountryCodeFromTimezone} from "./flag.js";
 
 function renderWatch(parent, timeZone = null, interpolator = d3.interpolateGreys, font = "futural", size = 150) {
   let timer;
   const strokeWidth = 3;
-  const strokeRadius = strokeWidth * 0;
+  const strokeRadius = Math.max(8, size * 0.08);
 
   // Create a sequential color scale: earlier = lighter, later = darker
   // Maps 0-24 hours to light-dark colors
@@ -56,7 +55,6 @@ function renderWatch(parent, timeZone = null, interpolator = d3.interpolateGreys
     // Determine stroke color based on background brightness
     const luminance = getLuminance(fillColor);
     const strokeColor = luminance < 0.5 ? "white" : "black";
-    const rectStrokeColor = "black";
 
     const digits = apack
       .text(`${hours}${minutes}${seconds}`, {
@@ -83,7 +81,6 @@ function renderWatch(parent, timeZone = null, interpolator = d3.interpolateGreys
       .attr("width", size - strokeWidth * 2)
       .attr("height", size - strokeWidth * 2)
       .attr("fill", fillColor)
-      // .attr("stroke", rectStrokeColor)
       .attr("rx", strokeRadius)
       .attr("ry", strokeRadius)
       .attr("stroke-width", strokeWidth);
@@ -112,6 +109,49 @@ function renderWatch(parent, timeZone = null, interpolator = d3.interpolateGreys
   };
 }
 
+function resolveTimeZone(timeZone) {
+  if (timeZone) return timeZone;
+  try {
+    return Intl.DateTimeFormat().resolvedOptions().timeZone;
+  } catch {
+    return "UTC";
+  }
+}
+
+function formatUtcOffset(timeZone) {
+  const resolved = resolveTimeZone(timeZone);
+
+  try {
+    const parts = new Intl.DateTimeFormat("en-US", {
+      timeZone: resolved,
+      timeZoneName: "shortOffset",
+    }).formatToParts(new Date());
+    const raw = parts.find((p) => p.type === "timeZoneName")?.value || "GMT";
+    // Normalize GMT±N / UTC±N → UTC±N, GMT → UTC+0
+    const normalized = raw.replace(/^GMT/i, "UTC").replace(/^UTC$/i, "UTC+0");
+    return normalized.replace(/UTC([+-])0*(\d+)(?::(\d+))?$/, (_, sign, hours, mins) => {
+      if (mins && mins !== "00") return `UTC${sign}${parseInt(hours, 10)}:${mins}`;
+      return `UTC${sign}${parseInt(hours, 10)}`;
+    });
+  } catch {
+    return "UTC";
+  }
+}
+
+function formatDateLabel(timeZone) {
+  const resolved = resolveTimeZone(timeZone);
+  try {
+    return new Intl.DateTimeFormat("en-GB", {
+      timeZone: resolved,
+      weekday: "short",
+      day: "numeric",
+      month: "short",
+    }).format(new Date());
+  } catch {
+    return "";
+  }
+}
+
 export default function Watch({
   timeZone = null,
   interpolator = d3.interpolateGreys,
@@ -119,11 +159,11 @@ export default function Watch({
   onClick,
   fixedSize,
   hideLabel = false,
+  featured = false,
 }) {
   const containerRef = useRef(null);
   const watchRef = useRef(null);
   const [size, setSize] = useState(fixedSize || 150);
-  const [isHovered, setIsHovered] = useState(false);
 
   // If fixedSize is provided, use it directly; otherwise use ResizeObserver
   useEffect(() => {
@@ -157,92 +197,114 @@ export default function Watch({
     }
   }, [timeZone, interpolator, font, size]);
 
-  const timeZoneLabel = timeZone 
-    ? timeZone === "UTC" 
-      ? "UTC" 
-      : timeZone.split("/").pop().replace(/_/g, " ")
-    : "Local";
-  const countryCode = timeZone ? getCountryCodeFromTimezone(timeZone) : null;
+  const isLocal = !timeZone;
+  const isUtc = timeZone === "UTC";
+
+  const timeZoneLabel = useMemo(() => {
+    if (featured && isLocal) return "Local time";
+    if (featured && isUtc) return "Coordinated Universal";
+    if (isUtc) return "UTC";
+    if (isLocal) return "Local";
+    return timeZone.split("/").pop().replace(/_/g, " ");
+  }, [featured, isLocal, isUtc, timeZone]);
+
+  const eyebrowLabel = useMemo(() => {
+    if (isLocal) return "Local";
+    if (isUtc) return "UTC";
+    return null;
+  }, [isLocal, isUtc]);
+
+  const mapsQuery = useMemo(() => {
+    if (isLocal) {
+      try {
+        return Intl.DateTimeFormat().resolvedOptions().timeZone.split("/").pop().replace(/_/g, " ");
+      } catch {
+        return "Local";
+      }
+    }
+    if (isUtc) return "UTC";
+    return timeZone.split("/").pop().replace(/_/g, " ");
+  }, [isLocal, isUtc, timeZone]);
+
+  const utcOffset = useMemo(() => formatUtcOffset(timeZone), [timeZone]);
+  const dateLabel = useMemo(() => formatDateLabel(timeZone), [timeZone]);
+  const metaLine = dateLabel ? `${dateLabel} · ${utcOffset}` : utcOffset;
+  const flagTimezone = useMemo(() => {
+    if (isUtc) return null;
+    if (timeZone) return timeZone;
+    return resolveTimeZone(null);
+  }, [isUtc, timeZone]);
+  const countryCode = flagTimezone ? getCountryCodeFromTimezone(flagTimezone) : null;
   const flagEmoji = countryCode ? getFlagEmoji(countryCode) : "";
 
-  return (
+  const faceClassName = ["aclock-card-face", fixedSize !== undefined ? "is-fixed" : ""]
+    .filter(Boolean)
+    .join(" ");
+
+  const faceStyle =
+    fixedSize !== undefined ? {"--aclock-face-size": `${fixedSize}px`} : undefined;
+
+  const face = (
     <div
-      onClick={onClick}
-      onMouseEnter={() => setIsHovered(true)}
-      onMouseLeave={() => setIsHovered(false)}
-      style={{
-        display: "inline-flex",
-        flexDirection: "column",
-        alignItems: "start",
-        width: "100%",
-        cursor: onClick ? "pointer" : "default",
-      }}
+      ref={fixedSize !== undefined ? null : containerRef}
+      className={faceClassName}
+      style={hideLabel ? faceStyle : undefined}
     >
-      <div
-        ref={fixedSize ? null : containerRef}
-        style={{
-          width: fixedSize ? `${fixedSize}px` : "100%",
-          height: fixedSize ? `${fixedSize}px` : "auto",
-          paddingTop: fixedSize ? 0 : "100%",
-          position: "relative",
-        }}
-      >
-        <div
-          ref={watchRef}
-          style={{
-            position: "absolute",
-            top: 0,
-            left: 0,
-            width: "100%",
-            height: "100%",
-          }}
-        ></div>
+      <div ref={watchRef} className="aclock-card-face-inner" />
+    </div>
+  );
+
+  // Detail / preview: bare face only (parent supplies card chrome)
+  if (hideLabel) {
+    return face;
+  }
+
+  const cardClassName = [
+    "aclock-card",
+    featured ? "is-featured" : "",
+    !onClick ? "is-static" : "",
+  ]
+    .filter(Boolean)
+    .join(" ");
+
+  if (featured) {
+    return (
+      <div className={cardClassName} onClick={onClick} style={faceStyle}>
+        {face}
+        <div className="aclock-card-meta aclock-card-meta-featured">
+          {eyebrowLabel && <p className="aclock-card-eyebrow">{eyebrowLabel}</p>}
+          <a
+            href={`https://www.google.com/maps/search/?api=1&query=${encodeURIComponent(mapsQuery)}`}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="aclock-card-name"
+            onClick={(e) => e.stopPropagation()}
+          >
+            {flagEmoji ? <span className="aclock-card-flag">{flagEmoji}</span> : null}
+            <span>{timeZoneLabel}</span>
+          </a>
+          <p className="aclock-card-offset">{metaLine}</p>
+        </div>
       </div>
-      {timeZoneLabel && !hideLabel && (
+    );
+  }
+
+  return (
+    <div className={cardClassName} onClick={onClick} style={faceStyle}>
+      {face}
+      <div className="aclock-card-meta">
         <a
-          href={`https://www.google.com/maps/search/?api=1&query=${encodeURIComponent(timeZoneLabel)}`}
+          href={`https://www.google.com/maps/search/?api=1&query=${encodeURIComponent(mapsQuery)}`}
           target="_blank"
           rel="noopener noreferrer"
+          className="aclock-card-name"
           onClick={(e) => e.stopPropagation()}
-          style={{
-            width: "100%",
-            whiteSpace: "nowrap",
-            textOverflow: "ellipsis",
-            overflow: "hidden",
-            textAlign: "center",
-            marginTop: "0.5rem",
-            fontSize: "0.875rem",
-            color: "#1b1e23",
-            display: "flex",
-            alignItems: "center",
-            justifyContent: "center",
-            gap: "0.25rem",
-            cursor: "pointer",
-            textDecoration: timeZoneLabel === "Local" || timeZoneLabel === "UTC" ? "underline" : "none",
-          }}
-          onMouseEnter={(e) => {
-            setIsHovered(true);
-            e.stopPropagation();
-          }}
-          onMouseLeave={(e) => {
-            setIsHovered(false);
-            e.stopPropagation();
-          }}
         >
-          {isHovered && flagEmoji ? <span>{flagEmoji} </span> : ""}
+          {flagEmoji ? <span className="aclock-card-flag">{flagEmoji}</span> : null}
           <span>{timeZoneLabel}</span>
-          {isHovered && (
-            <MapPin
-              className="inline-block"
-              style={{
-                width: "0.875rem",
-                height: "0.875rem",
-                flexShrink: 0,
-              }}
-            />
-          )}
         </a>
-      )}
+        <p className="aclock-card-offset">{utcOffset}</p>
+      </div>
     </div>
   );
 }

--- a/web/components/aclock/Watch.jsx
+++ b/web/components/aclock/Watch.jsx
@@ -7,16 +7,10 @@ function renderWatch(parent, timeZone = null, interpolator = d3.interpolateGreys
   let timer;
   const strokeWidth = 3;
   const strokeRadius = Math.max(8, size * 0.08);
+  const colorScale = d3.scaleSequential(interpolator).domain([0, 24]);
 
-  // Create a sequential color scale: earlier = lighter, later = darker
-  // Maps 0-24 hours to light-dark colors
-  const colorScale = d3.scaleSequential(interpolator).domain([0, 24]); // 0 hours = light, 24 hours = dark
-
-  // Calculate relative luminance of a color (0-1, where 0 is black and 1 is white)
   function getLuminance(color) {
-    // Parse RGB from color string (e.g., "rgb(128, 128, 128)" or "#808080")
     const rgb = d3.rgb(color);
-    // Relative luminance formula
     return 0.2126 * (rgb.r / 255) + 0.7152 * (rgb.g / 255) + 0.0722 * (rgb.b / 255);
   }
 
@@ -25,21 +19,23 @@ function renderWatch(parent, timeZone = null, interpolator = d3.interpolateGreys
   }
 
   function update() {
-    let hours, minutes, seconds;
+    let hours;
+    let minutes;
+    let seconds;
     let hoursNum;
+
     if (timeZone) {
-      const formatter = new Intl.DateTimeFormat("en-US", {
+      const parts = new Intl.DateTimeFormat("en-US", {
         timeZone,
         hour: "2-digit",
         minute: "2-digit",
         second: "2-digit",
         hour12: false,
-      });
-      const parts = formatter.formatToParts(new Date());
-      hoursNum = parseInt(parts.find((p) => p.type === "hour").value);
+      }).formatToParts(new Date());
+      hoursNum = parseInt(parts.find((p) => p.type === "hour").value, 10) % 24;
       hours = formatDigit(hoursNum);
-      minutes = formatDigit(parseInt(parts.find((p) => p.type === "minute").value));
-      seconds = formatDigit(parseInt(parts.find((p) => p.type === "second").value));
+      minutes = formatDigit(parseInt(parts.find((p) => p.type === "minute").value, 10));
+      seconds = formatDigit(parseInt(parts.find((p) => p.type === "second").value, 10));
     } else {
       const now = new Date();
       hoursNum = now.getHours();
@@ -48,13 +44,9 @@ function renderWatch(parent, timeZone = null, interpolator = d3.interpolateGreys
       seconds = formatDigit(now.getSeconds());
     }
 
-    // Calculate time as decimal hours (including minutes and seconds for smooth transition)
-    const timeDecimal = hoursNum + parseInt(minutes) / 60 + parseInt(seconds) / 3600;
+    const timeDecimal = hoursNum + parseInt(minutes, 10) / 60 + parseInt(seconds, 10) / 3600;
     const fillColor = colorScale(timeDecimal);
-
-    // Determine stroke color based on background brightness
-    const luminance = getLuminance(fillColor);
-    const strokeColor = luminance < 0.5 ? "white" : "black";
+    const strokeColor = getLuminance(fillColor) < 0.5 ? "white" : "black";
 
     const digits = apack
       .text(`${hours}${minutes}${seconds}`, {
@@ -82,11 +74,9 @@ function renderWatch(parent, timeZone = null, interpolator = d3.interpolateGreys
       .attr("height", size - strokeWidth * 2)
       .attr("fill", fillColor)
       .attr("rx", strokeRadius)
-      .attr("ry", strokeRadius)
-      .attr("stroke-width", strokeWidth);
+      .attr("ry", strokeRadius);
 
     svg.node().appendChild(digits);
-
     parent.innerHTML = "";
     parent.appendChild(svg.node());
   }
@@ -103,10 +93,7 @@ function renderWatch(parent, timeZone = null, interpolator = d3.interpolateGreys
     }
   }
 
-  return {
-    start,
-    stop,
-  };
+  return {start, stop};
 }
 
 function resolveTimeZone(timeZone) {
@@ -118,6 +105,10 @@ function resolveTimeZone(timeZone) {
   }
 }
 
+function cityLabelFromTimeZone(timeZone) {
+  return timeZone.split("/").pop().replace(/_/g, " ");
+}
+
 function formatUtcOffset(timeZone) {
   const resolved = resolveTimeZone(timeZone);
 
@@ -126,15 +117,30 @@ function formatUtcOffset(timeZone) {
       timeZone: resolved,
       timeZoneName: "shortOffset",
     }).formatToParts(new Date());
-    const raw = parts.find((p) => p.type === "timeZoneName")?.value || "GMT";
-    // Normalize GMT±N / UTC±N → UTC±N, GMT → UTC+0
-    const normalized = raw.replace(/^GMT/i, "UTC").replace(/^UTC$/i, "UTC+0");
-    return normalized.replace(/UTC([+-])0*(\d+)(?::(\d+))?$/, (_, sign, hours, mins) => {
-      if (mins && mins !== "00") return `UTC${sign}${parseInt(hours, 10)}:${mins}`;
-      return `UTC${sign}${parseInt(hours, 10)}`;
-    });
+    const raw = parts.find((p) => p.type === "timeZoneName")?.value;
+    if (raw) {
+      const normalized = raw.replace(/^GMT/i, "UTC").replace(/^UTC$/i, "UTC+0");
+      return normalized.replace(/UTC([+-])0*(\d+)(?::(\d+))?$/, (_, sign, hours, mins) => {
+        if (mins && mins !== "00") return `UTC${sign}${parseInt(hours, 10)}:${mins}`;
+        return `UTC${sign}${parseInt(hours, 10)}`;
+      });
+    }
   } catch {
-    return "UTC";
+    // fall through to manual offset
+  }
+
+  try {
+    const now = new Date();
+    const utc = new Date(now.toLocaleString("en-US", {timeZone: "UTC"}));
+    const local = new Date(now.toLocaleString("en-US", {timeZone: resolved}));
+    const offsetMin = Math.round((local - utc) / 60000);
+    const sign = offsetMin >= 0 ? "+" : "-";
+    const abs = Math.abs(offsetMin);
+    const hours = Math.floor(abs / 60);
+    const mins = abs % 60;
+    return mins ? `UTC${sign}${hours}:${String(mins).padStart(2, "0")}` : `UTC${sign}${hours}`;
+  } catch {
+    return "";
   }
 }
 
@@ -157,44 +163,31 @@ export default function Watch({
   interpolator = d3.interpolateGreys,
   font = "futural",
   onClick,
-  fixedSize,
-  hideLabel = false,
   featured = false,
 }) {
   const containerRef = useRef(null);
   const watchRef = useRef(null);
-  const [size, setSize] = useState(fixedSize || 150);
+  const [size, setSize] = useState(150);
 
-  // If fixedSize is provided, use it directly; otherwise use ResizeObserver
   useEffect(() => {
-    if (fixedSize !== undefined) {
-      setSize(fixedSize);
-      return;
-    }
-
     if (!containerRef.current) return;
 
     const resizeObserver = new ResizeObserver((entries) => {
       for (const entry of entries) {
-        const width = entry.contentRect.width;
-        setSize(width);
+        setSize(entry.contentRect.width);
       }
     });
 
     resizeObserver.observe(containerRef.current);
-
-    return () => {
-      resizeObserver.disconnect();
-    };
-  }, [fixedSize]);
+    return () => resizeObserver.disconnect();
+  }, []);
 
   useEffect(() => {
-    if (watchRef.current && size > 0) {
-      watchRef.current.innerHTML = "";
-      const {start, stop} = renderWatch(watchRef.current, timeZone, interpolator, font, size);
-      start();
-      return () => stop();
-    }
+    if (!watchRef.current || size <= 0) return;
+    watchRef.current.innerHTML = "";
+    const {start, stop} = renderWatch(watchRef.current, timeZone, interpolator, font, size);
+    start();
+    return () => stop();
   }, [timeZone, interpolator, font, size]);
 
   const isLocal = !timeZone;
@@ -205,59 +198,34 @@ export default function Watch({
     if (featured && isUtc) return "Coordinated Universal";
     if (isUtc) return "UTC";
     if (isLocal) return "Local";
-    return timeZone.split("/").pop().replace(/_/g, " ");
+    return cityLabelFromTimeZone(timeZone);
   }, [featured, isLocal, isUtc, timeZone]);
 
-  const eyebrowLabel = useMemo(() => {
-    if (isLocal) return "Local";
-    if (isUtc) return "UTC";
-    return null;
-  }, [isLocal, isUtc]);
+  const eyebrowLabel = isLocal ? "Local" : isUtc ? "UTC" : null;
 
   const mapsQuery = useMemo(() => {
     if (isLocal) {
       try {
-        return Intl.DateTimeFormat().resolvedOptions().timeZone.split("/").pop().replace(/_/g, " ");
+        return cityLabelFromTimeZone(Intl.DateTimeFormat().resolvedOptions().timeZone);
       } catch {
         return "Local";
       }
     }
     if (isUtc) return "UTC";
-    return timeZone.split("/").pop().replace(/_/g, " ");
+    return cityLabelFromTimeZone(timeZone);
   }, [isLocal, isUtc, timeZone]);
 
   const utcOffset = useMemo(() => formatUtcOffset(timeZone), [timeZone]);
   const dateLabel = useMemo(() => formatDateLabel(timeZone), [timeZone]);
-  const metaLine = dateLabel ? `${dateLabel} · ${utcOffset}` : utcOffset;
+  const metaText = featured && dateLabel ? `${dateLabel} · ${utcOffset}` : utcOffset || dateLabel;
+
   const flagTimezone = useMemo(() => {
     if (isUtc) return null;
-    if (timeZone) return timeZone;
-    return resolveTimeZone(null);
+    return timeZone || resolveTimeZone(null);
   }, [isUtc, timeZone]);
-  const countryCode = flagTimezone ? getCountryCodeFromTimezone(flagTimezone) : null;
-  const flagEmoji = countryCode ? getFlagEmoji(countryCode) : "";
-
-  const faceClassName = ["aclock-card-face", fixedSize !== undefined ? "is-fixed" : ""]
-    .filter(Boolean)
-    .join(" ");
-
-  const faceStyle =
-    fixedSize !== undefined ? {"--aclock-face-size": `${fixedSize}px`} : undefined;
-
-  const face = (
-    <div
-      ref={fixedSize !== undefined ? null : containerRef}
-      className={faceClassName}
-      style={hideLabel ? faceStyle : undefined}
-    >
-      <div ref={watchRef} className="aclock-card-face-inner" />
-    </div>
-  );
-
-  // Detail / preview: bare face only (parent supplies card chrome)
-  if (hideLabel) {
-    return face;
-  }
+  const flagEmoji = flagTimezone
+    ? getFlagEmoji(getCountryCodeFromTimezone(flagTimezone))
+    : "";
 
   const cardClassName = [
     "aclock-card",
@@ -267,32 +235,13 @@ export default function Watch({
     .filter(Boolean)
     .join(" ");
 
-  if (featured) {
-    return (
-      <div className={cardClassName} onClick={onClick} style={faceStyle}>
-        {face}
-        <div className="aclock-card-meta aclock-card-meta-featured">
-          {eyebrowLabel && <p className="aclock-card-eyebrow">{eyebrowLabel}</p>}
-          <a
-            href={`https://www.google.com/maps/search/?api=1&query=${encodeURIComponent(mapsQuery)}`}
-            target="_blank"
-            rel="noopener noreferrer"
-            className="aclock-card-name"
-            onClick={(e) => e.stopPropagation()}
-          >
-            {flagEmoji ? <span className="aclock-card-flag">{flagEmoji}</span> : null}
-            <span>{timeZoneLabel}</span>
-          </a>
-          <p className="aclock-card-offset">{metaLine}</p>
-        </div>
-      </div>
-    );
-  }
-
   return (
-    <div className={cardClassName} onClick={onClick} style={faceStyle}>
-      {face}
-      <div className="aclock-card-meta">
+    <div className={cardClassName} onClick={onClick}>
+      <div ref={containerRef} className="aclock-card-face">
+        <div ref={watchRef} className="aclock-card-face-inner" />
+      </div>
+      <div className={`aclock-card-meta${featured ? " aclock-card-meta-featured" : ""}`}>
+        {featured && eyebrowLabel ? <p className="aclock-card-eyebrow">{eyebrowLabel}</p> : null}
         <a
           href={`https://www.google.com/maps/search/?api=1&query=${encodeURIComponent(mapsQuery)}`}
           target="_blank"
@@ -303,7 +252,7 @@ export default function Watch({
           {flagEmoji ? <span className="aclock-card-flag">{flagEmoji}</span> : null}
           <span>{timeZoneLabel}</span>
         </a>
-        <p className="aclock-card-offset">{utcOffset}</p>
+        {metaText ? <p className="aclock-card-offset">{metaText}</p> : null}
       </div>
     </div>
   );

--- a/web/components/aclock/WatchPage.jsx
+++ b/web/components/aclock/WatchPage.jsx
@@ -1,9 +1,8 @@
 import {useState, useMemo} from "react";
 import {useRouter} from "next/navigation";
 import Watch from "./Watch.jsx";
-import {Globe, MapPin} from "lucide-react";
+import {Globe} from "lucide-react";
 import {cityNameToTimezone} from "./utils.js";
-import {getFlagEmoji, getCountryCodeFromTimezone} from "./flag.js";
 import {DEFAULT_FONT, DEFAULT_INTERPOLATOR, interpolators, VALID_FONTS} from "./constants.js";
 
 export default function WatchPage({cityName}) {
@@ -24,24 +23,29 @@ export default function WatchPage({cityName}) {
     }
   }, []);
 
+  const isLocalPage = cityName?.toLowerCase() === "local";
+  const isUtcPage = cityName?.toLowerCase() === "utc";
+
   const selectedTimeZone = useMemo(() => {
     if (!cityName) return null;
 
-    if (cityName.toLowerCase() === "local") {
+    if (isLocalPage) {
       try {
         return Intl.DateTimeFormat().resolvedOptions().timeZone;
       } catch (e) {
         return null;
       }
     }
-    if (cityName.toLowerCase() === "utc") {
+    if (isUtcPage) {
       return "UTC";
     }
 
     return cityNameToTimezone(cityName, timeZones);
-  }, [cityName, timeZones]);
+  }, [cityName, timeZones, isLocalPage, isUtcPage]);
 
-  const isValidTimeZone = selectedTimeZone && (selectedTimeZone === "UTC" || timeZones.includes(selectedTimeZone));
+  const isValidTimeZone =
+    isLocalPage ||
+    (selectedTimeZone && (selectedTimeZone === "UTC" || timeZones.includes(selectedTimeZone)));
 
   const fontAssignment = useMemo(() => {
     if (fontOption !== "random" || !isValidTimeZone) {
@@ -50,54 +54,15 @@ export default function WatchPage({cityName}) {
     return VALID_FONTS[Math.floor(Math.random() * VALID_FONTS.length)];
   }, [fontOption, isValidTimeZone]);
 
-  const countryCode = selectedTimeZone && selectedTimeZone !== "UTC" ? getCountryCodeFromTimezone(selectedTimeZone) : null;
-  const flagEmoji = countryCode ? getFlagEmoji(countryCode) : "";
-  const countryName = selectedTimeZone
-    ? selectedTimeZone === "UTC"
-      ? "UTC"
-      : selectedTimeZone.split("/").pop().replace(/_/g, " ")
-    : "Local";
-
-  const localTimeZone = useMemo(() => {
-    try {
-      return Intl.DateTimeFormat().resolvedOptions().timeZone;
-    } catch (e) {
-      return null;
-    }
-  }, []);
-
-  const localFontAssignment = useMemo(() => {
-    if (fontOption !== "random" || !localTimeZone) {
-      return fontOption;
-    }
-    return VALID_FONTS[Math.floor(Math.random() * VALID_FONTS.length)];
-  }, [fontOption, localTimeZone]);
-
   const goHome = () => router.push("/aclock/");
 
   if (!isValidTimeZone) {
     return (
       <div className="aclock-watch-page">
-        <div className="aclock-watch-inner">
-          <button onClick={goHome} className="aclock-icon-button" aria-label="Home">
+        <div className="aclock-watch-detail">
+          <button type="button" onClick={goHome} className="aclock-icon-button" aria-label="Back to world clocks">
             <Globe className="h-5 w-5" />
           </button>
-
-          {localTimeZone && (
-            <div className="aclock-watch-preview">
-              <div style={{width: "150px", height: "150px"}}>
-                <Watch
-                  key={localTimeZone}
-                  timeZone={localTimeZone}
-                  interpolator={interpolators[interpolatorOption]}
-                  font={localFontAssignment}
-                  fixedSize={150}
-                  hideLabel={true}
-                />
-              </div>
-            </div>
-          )}
-
           <div className="aclock-watch-error">
             <h1>Time zone not found</h1>
             <button type="button" onClick={goHome} className="aclock-text-button">
@@ -109,38 +74,22 @@ export default function WatchPage({cityName}) {
     );
   }
 
+  const watchTimeZone = isLocalPage ? null : selectedTimeZone;
+
   return (
     <div className="aclock-watch-page">
-      <div className="aclock-watch-inner">
-        <div className="aclock-watch-header">
-          <button onClick={goHome} className="aclock-icon-button" aria-label="Home">
-            <Globe className="h-5 w-5" />
-          </button>
-          {countryName && (
-            <a
-              href={`https://www.google.com/maps/search/?api=1&query=${encodeURIComponent(countryName)}`}
-              target="_blank"
-              rel="noopener noreferrer"
-              className="aclock-watch-location"
-            >
-              {flagEmoji && <span className="text-2xl">{flagEmoji}</span>}
-              <span className="font-medium">{countryName} Time</span>
-              <MapPin className="h-4 w-4" />
-            </a>
-          )}
-        </div>
-
-        <div className="aclock-watch-center">
-          <div style={{width: "150px", height: "150px"}}>
-            <Watch
-              key={selectedTimeZone}
-              timeZone={selectedTimeZone}
-              interpolator={interpolators[interpolatorOption]}
-              font={fontAssignment}
-              fixedSize={150}
-              hideLabel={true}
-            />
-          </div>
+      <div className="aclock-watch-detail">
+        <button type="button" onClick={goHome} className="aclock-icon-button" aria-label="Back to world clocks">
+          <Globe className="h-5 w-5" />
+        </button>
+        <div className="aclock-watch-detail-card">
+          <Watch
+            key={watchTimeZone || "local"}
+            timeZone={watchTimeZone}
+            featured
+            interpolator={interpolators[interpolatorOption]}
+            font={fontAssignment}
+          />
         </div>
       </div>
     </div>

--- a/web/components/aclock/WatchPage.jsx
+++ b/web/components/aclock/WatchPage.jsx
@@ -7,73 +7,46 @@ import {DEFAULT_FONT, DEFAULT_INTERPOLATOR, interpolators, VALID_FONTS} from "./
 
 export default function WatchPage({cityName}) {
   const router = useRouter();
+  const slug = cityName?.toLowerCase() || "";
+  const isLocalPage = slug === "local";
+  const isUtcPage = slug === "utc";
 
-  const [interpolatorOption] = useState(() => {
-    return localStorage.getItem("watchInterpolatorOption") || DEFAULT_INTERPOLATOR;
-  });
-  const [fontOption] = useState(() => {
-    return localStorage.getItem("watchFontOption") || DEFAULT_FONT;
-  });
+  const [interpolatorOption] = useState(
+    () => localStorage.getItem("watchInterpolatorOption") || DEFAULT_INTERPOLATOR,
+  );
+  const [fontOption] = useState(() => localStorage.getItem("watchFontOption") || DEFAULT_FONT);
 
   const timeZones = useMemo(() => {
     try {
       return Intl.supportedValuesOf("timeZone");
-    } catch (e) {
+    } catch {
       return ["America/New_York", "Europe/London", "Asia/Tokyo", "Australia/Sydney"];
     }
   }, []);
 
-  const isLocalPage = cityName?.toLowerCase() === "local";
-  const isUtcPage = cityName?.toLowerCase() === "utc";
-
   const selectedTimeZone = useMemo(() => {
-    if (!cityName) return null;
-
     if (isLocalPage) {
       try {
         return Intl.DateTimeFormat().resolvedOptions().timeZone;
-      } catch (e) {
+      } catch {
         return null;
       }
     }
-    if (isUtcPage) {
-      return "UTC";
-    }
-
+    if (isUtcPage) return "UTC";
+    if (!cityName) return null;
     return cityNameToTimezone(cityName, timeZones);
   }, [cityName, timeZones, isLocalPage, isUtcPage]);
 
   const isValidTimeZone =
     isLocalPage ||
-    (selectedTimeZone && (selectedTimeZone === "UTC" || timeZones.includes(selectedTimeZone)));
+    (selectedTimeZone != null && (selectedTimeZone === "UTC" || timeZones.includes(selectedTimeZone)));
 
   const fontAssignment = useMemo(() => {
-    if (fontOption !== "random" || !isValidTimeZone) {
-      return fontOption;
-    }
+    if (fontOption !== "random" || !isValidTimeZone) return fontOption;
     return VALID_FONTS[Math.floor(Math.random() * VALID_FONTS.length)];
   }, [fontOption, isValidTimeZone]);
 
   const goHome = () => router.push("/aclock/");
-
-  if (!isValidTimeZone) {
-    return (
-      <div className="aclock-watch-page">
-        <div className="aclock-watch-detail">
-          <button type="button" onClick={goHome} className="aclock-icon-button" aria-label="Back to world clocks">
-            <Globe className="h-5 w-5" />
-          </button>
-          <div className="aclock-watch-error">
-            <h1>Time zone not found</h1>
-            <button type="button" onClick={goHome} className="aclock-text-button">
-              Return to home
-            </button>
-          </div>
-        </div>
-      </div>
-    );
-  }
-
   const watchTimeZone = isLocalPage ? null : selectedTimeZone;
 
   return (
@@ -82,15 +55,24 @@ export default function WatchPage({cityName}) {
         <button type="button" onClick={goHome} className="aclock-icon-button" aria-label="Back to world clocks">
           <Globe className="h-5 w-5" />
         </button>
-        <div className="aclock-watch-detail-card">
-          <Watch
-            key={watchTimeZone || "local"}
-            timeZone={watchTimeZone}
-            featured
-            interpolator={interpolators[interpolatorOption]}
-            font={fontAssignment}
-          />
-        </div>
+        {isValidTimeZone ? (
+          <div className="aclock-watch-detail-card">
+            <Watch
+              key={watchTimeZone || "local"}
+              timeZone={watchTimeZone}
+              featured
+              interpolator={interpolators[interpolatorOption]}
+              font={fontAssignment}
+            />
+          </div>
+        ) : (
+          <div className="aclock-watch-error">
+            <h1>Time zone not found</h1>
+            <button type="button" onClick={goHome} className="aclock-text-button">
+              Return to home
+            </button>
+          </div>
+        )}
       </div>
     </div>
   );

--- a/web/components/aclock/WatchPage.jsx
+++ b/web/components/aclock/WatchPage.jsx
@@ -51,10 +51,10 @@ export default function WatchPage({cityName}) {
 
   return (
     <div className="aclock-watch-page">
+      <button type="button" onClick={goHome} className="aclock-icon-button aclock-watch-home" aria-label="Back to world clocks">
+        <Globe className="h-5 w-5" />
+      </button>
       <div className="aclock-watch-detail">
-        <button type="button" onClick={goHome} className="aclock-icon-button" aria-label="Back to world clocks">
-          <Globe className="h-5 w-5" />
-        </button>
         {isValidTimeZone ? (
           <div className="aclock-watch-detail-card">
             <Watch


### PR DESCRIPTION
## Summary
- Restyle `/aclock` to a cream editorial UI with rounded timezone cards, always-visible flags, and UTC offsets while keeping APack packed-digit faces
- Add a featured Local/UTC top row with horizontal card layout, and simplify city detail pages to a centered card with a globe back control (no scroll)
- Pre-generate all timezone city routes in `generateStaticParams` so static export works for `/aclock/{city}/`

## Test plan
- [ ] Open `/aclock/` and confirm cream background, left-aligned header, legend, toolbar, and divider
- [ ] Confirm Local and UTC occupy the featured top row with horizontal layout (face left, labels right)
- [ ] Confirm city cards show flags without hover and include UTC offsets
- [ ] Click a city (e.g. `/aclock/niue/`) and confirm a centered single card, globe returns home, page does not scroll
- [ ] Change Digits/Color/Sort and confirm faces update; search filters the grid


Made with [Cursor](https://cursor.com)